### PR TITLE
Add cycle 1/3 progress update

### DIFF
--- a/proposal.md
+++ b/proposal.md
@@ -323,6 +323,27 @@ oriented interface or via a set of functions familiar to MATLAB users.
 > Provide a short summary of progress towards the deliverables in your
 > currently funded proposal (maximum of 250 words)
 
+For the round 1 cycle, the grant supported one developer at 40% (Thomas
+Caswell), one graduate student (Hannah Aizenman) with partial summer support
+for her advisor (Michael Grossberg), and a full time Research Software
+Engineer.  For the latter we ran a search and hired Elliott Sales de Andrade
+who started March 2020 for one year.  This same structure continued into the
+round 3 cycle, over the 2021 year, with the two-month delay for Elliott.
+
+Elliott has focused on the maintenance and support aspect of the grant.  We hit
+our target of a net reduction of open PRs by 50/quarter and are making progress
+on reducing the number of open issues.  Our initial estimates of the effort per
+issue closed were too optimistic; while we increased the rate of issues closed,
+the number of issues opened also increased.  As part of ongoing maintenance,
+Elliott increased automation of the release process and CI infrastructure,
+enabling us to make 2 feature and 6 bug-fix releases in cycle 1, with an
+additional 1 feature and 2 bug-fix releases in cycle 3 to-date.  Elliott
+implemented or shepherded to completion several mid-sized and high-impact
+projects including toolkit-specific work (Hi-DPI improvements, JavaScript
+modernization), feature implementation (3D-specific plots, domain-specific plot
+types), and internal refactors (deprecation cleanup, internal storage
+refactors).
+
 
 > Previous progress report:
 

--- a/proposal.md
+++ b/proposal.md
@@ -322,3 +322,27 @@ oriented interface or via a set of functions familiar to MATLAB users.
 
 > Provide a short summary of progress towards the deliverables in your
 > currently funded proposal (maximum of 250 words)
+
+
+> Previous progress report:
+
+The current grant is supporting one developer at 40% (Thomas Caswell), one
+graduate student (Hannah Aizenman) with partial summer support for her advisor
+(Michael Grossberg), and a full time Research Software Engineer.  For the latter
+we ran a search and hired Elliott Sales de Andrade who started in mid-March.
+
+Elliott has focused on the maintenance and support aspect of the grant.  We hit
+our target of a net reduction of open PRs by 50/quarter and are making progress
+on reducing the number of open issues.  Our initial estimates of the effort per
+issue closed were too optimistic; however, we merged several mid-sized and
+high-impact projects (documentation, JavaScript modernization, and a complex
+axes layout helper).  Additionally we drafted new governance and contributor
+onboarding guidelines and had 2 feature and 4 bug-fix releases.
+
+We presented our new architecture ideas to the scientific library development
+community at the SciPy 2020 maintainers track.  We designed the prototype API to
+have a clean separation between the DataSource, Artist, and rendering layers.
+We started implementing sample DataSources and Artists to formalize and
+validate the interface between them.  Because the prototype is still developing
+rapidly, we are postponing working with a downstream partner until the API has
+stabilized.


### PR DESCRIPTION
It's a bit long right now, but I figure it's easier to trim out stuff than go looking for it later. I wasn't sure how much to mention cycle 1, so we can trim that description out if not needed.